### PR TITLE
fix: increase num_traces to prevent trace eviction

### DIFF
--- a/tail-sampling/otel-collector-config.yaml
+++ b/tail-sampling/otel-collector-config.yaml
@@ -7,8 +7,8 @@ processors:
   batch:
   tail_sampling:
     decision_wait: 10s
-    num_traces: 100
-    expected_new_traces_per_sec: 10
+    num_traces: 50000
+    expected_new_traces_per_sec: 100
     policies:
       - name: errors-policy
         type: status_code


### PR DESCRIPTION
## Summary
- `num_traces` を `100` → `50000` に増加
- `expected_new_traces_per_sec` を `10` → `100` に増加

## Problem
k6 で 814 リクエスト送信時、期待値 ~215 トレースに対し Jaeger に 47 トレースしか表示されなかった。
`num_traces: 100` が小さすぎて、`decision_wait: 10s` の間にバッファが溢れ、トレースが評価前に強制排出されていた。

## Test plan
- [ ] `docker compose up --build` で再起動
- [ ] k6 実行後、Jaeger UI でトレース数が ~215 前後になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)