### PR TITLE
docs: add README for simple, bridge, collector, microservice, multi-package

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,39 @@
+# Bridge (OpenCensus → OpenTelemetry)
+
+OpenCensus から OpenTelemetry への移行ブリッジのサンプルです。
+`go.opentelemetry.io/otel/bridge/opencensus` を使い、既存の OpenCensus 計装コードを OpenTelemetry に統合します。
+
+## アーキテクチャ
+
+```
+┌──────────────┐         ┌───────────────────┐
+│  API (:8000) │────────→│ BigTable Emulator  │
+│  OTel + OC   │         │ (:8086)            │
+└──────┬───────┘         └───────────────────┘
+       │ Jaeger HTTP
+       ▼
+┌──────────────┐
+│   Jaeger     │
+│ (:16686 UI)  │
+└──────────────┘
+```
+
+## 特徴
+
+- **OpenCensus ブリッジ**: `bridge/opencensus` パッケージで OpenCensus の DefaultTracer を OpenTelemetry にルーティング
+- **BigTable 統合**: Google Cloud BigTable エミュレータを使ったデータ読み書き（OpenCensus で計装済み）
+- **統合トレース**: OpenCensus 由来のスパンと OpenTelemetry のスパンが同一トレースに統合される
+- **段階的移行**: 既存の OpenCensus コードを書き換えずに OpenTelemetry へ移行する方法を示す
+
+## ユースケース
+
+BigTable クライアントライブラリは内部で OpenCensus を使用しています。
+ブリッジを使うことで、アプリ側は OpenTelemetry に統一しつつ、ライブラリの OpenCensus トレースも Jaeger に統合できます。
+
+## 使い方
+
+```bash
+docker compose up --build
+curl http://localhost:8000/hello
+open http://localhost:16686
+```

--- a/collector/README.md
+++ b/collector/README.md
@@ -1,0 +1,69 @@
+# Collector
+
+OpenTelemetry Collector を介してトレースを複数バックエンド（Jaeger + Zipkin）にエクスポートするサンプルです。
+
+## アーキテクチャ
+
+```
+┌──────────┐     gRPC     ┌──────────────┐
+│ Gateway  │─────────────→│ Backend-gRPC │
+│ (:8000)  │              │ (:8080)      │
+└────┬─────┘              └──────┬───────┘
+     │ OTLP gRPC                 │ OTLP gRPC
+     └──────────┬────────────────┘
+                ▼
+       ┌─────────────────┐
+       │  OTel Collector  │
+       │  (:4317)         │
+       └───┬─────────┬───┘
+           ▼         ▼
+    ┌──────────┐ ┌──────────┐
+    │  Jaeger  │ │  Zipkin  │
+    │ (:16686) │ │ (:9411)  │
+    └──────────┘ └──────────┘
+```
+
+## 特徴
+
+- **OTel Collector 経由**: アプリは OTLP gRPC で Collector に送信、Collector が各バックエンドへ分配
+- **マルチバックエンド**: 1つのトレースデータを Jaeger と Zipkin の両方に同時エクスポート
+- **OTLP プロトコル**: Jaeger HTTP エクスポーターではなく、標準の OTLP gRPC を使用
+- **ParentBased サンプリング**: Gateway=100%, Backend=50%（Parent の判断を継承）
+
+## microservice/ との違い
+
+| 項目 | collector/ (本サンプル) | microservice/ |
+|------|----------------------|---------------|
+| エクスポート先 | OTel Collector | Jaeger へ直接 |
+| プロトコル | OTLP gRPC | Jaeger HTTP |
+| バックエンド | Jaeger + Zipkin | Jaeger のみ |
+| Collector | あり | なし |
+
+## Collector 設定
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:          # :4317 で OTLP gRPC を受信
+
+processors:
+  batch:             # バッチ処理で効率化
+
+exporters:
+  jaeger:            # Jaeger gRPC (:14250)
+  zipkin:            # Zipkin HTTP (:9411)
+```
+
+## 使い方
+
+```bash
+docker compose up --build
+curl http://localhost:8000/hello
+
+# Jaeger UI
+open http://localhost:16686
+
+# Zipkin UI
+open http://localhost:9411
+```

--- a/microservice/README.md
+++ b/microservice/README.md
@@ -1,0 +1,57 @@
+# Microservice
+
+HTTP + gRPC のマイクロサービス間で分散トレーシングを行うサンプルです。
+
+## アーキテクチャ
+
+```
+┌──────────┐     gRPC     ┌──────────────┐
+│ Gateway  │─────────────→│ Backend-gRPC │
+│ (:8000)  │              │ (:8080)      │
+│          │──→ httpbin.org               │
+└────┬─────┘              └──────┬───────┘
+     │ Jaeger HTTP                │ Jaeger HTTP
+     └──────────┬────────────────┘
+                ▼
+       ┌─────────────────┐
+       │     Jaeger       │
+       │  (:16686 UI)     │
+       └─────────────────┘
+```
+
+アプリから Jaeger へ直接エクスポートします。Collector は使いません。
+
+## 特徴
+
+- **gRPC 分散トレーシング**: `otelgrpc` のクライアント/サーバーインターセプターで自動計装
+- **HTTP 自動計装**: `otelhttp` でHTTP受信・送信を自動トレース
+- **コンテキスト伝搬**: gRPC メタデータを通じて Trace Context が自動伝搬
+- **外部 HTTP 呼び出し**: httpbin.org への呼び出しもトレースに含まれる
+- **AlwaysSample**: 全リクエストをトレース
+
+## `/hello` のトレース構造
+
+```
+gateway: server (otelhttp)
+├── gateway: grpc.helloworld.Greeter/SayHello (client)
+│   └── backend: grpc.helloworld.Greeter/SayHello (server)
+│       └── backend: operation (200ms)
+├── gateway: op1 (100ms)
+└── gateway: HTTP GET httpbin.org/delay/1
+```
+
+## collector/ との違い
+
+| 項目 | microservice/ (本サンプル) | collector/ |
+|------|--------------------------|-----------|
+| エクスポート先 | Jaeger へ直接 | OTel Collector 経由 |
+| プロトコル | Jaeger HTTP | OTLP gRPC |
+| バックエンド | Jaeger のみ | Jaeger + Zipkin |
+
+## 使い方
+
+```bash
+docker compose up --build
+curl http://localhost:8000/hello
+open http://localhost:16686
+```

--- a/multi-package/README.md
+++ b/multi-package/README.md
@@ -1,0 +1,57 @@
+# Multi-Package
+
+複数の Go パッケージにまたがるトレーシングのサンプルです。
+パッケージごとに独立した Tracer を持ち、スパンが正しく親子関係を維持することを示します。
+
+## アーキテクチャ
+
+```
+┌──────────────────────────────────┐
+│  API (:8000)                     │
+│  ┌─────┐  ┌─────────┐  ┌──────┐ │
+│  │ cmd │→│ service  │→│ util │ │──→ httpbin.org
+│  └─────┘  └─────────┘  └──────┘ │
+└──────────────┬───────────────────┘
+               │ Jaeger HTTP
+               ▼
+       ┌─────────────────┐
+       │     Jaeger       │
+       │  (:16686 UI)     │
+       └─────────────────┘
+```
+
+## 特徴
+
+- **パッケージ別 Tracer**: 各パッケージが `otel.Tracer("package/path")` で独自の Tracer を取得
+- **スパンの親子関係**: `context.Context` を渡すことで、パッケージを跨いでもトレースが繋がる
+- **3層構成**: `cmd`（エントリポイント）→ `service`（ビジネスロジック）→ `util`（ユーティリティ）
+- **AlwaysSample**: 全リクエストをトレース
+
+## パッケージ構成
+
+```
+multi-package/
+├── cmd/main.go          # エントリポイント、HTTP サーバー起動
+├── service/service.go   # HTTP ハンドラー、Operation1/2、HTTP クライアント
+├── util/util.go         # ユーティリティ関数 (Operation)
+└── telemetry/trace.go   # TracerProvider 初期化
+```
+
+## `/hello` のトレース構造
+
+```
+server (otelhttp)                    ← cmd パッケージ
+├── service: op1 (100ms)             ← service パッケージ
+├── service: HTTP GET httpbin.org    ← service パッケージ
+└── util: op (100ms)                 ← util パッケージ
+```
+
+Jaeger 上でスパンごとにどのパッケージ（Tracer）から発行されたか確認できます。
+
+## 使い方
+
+```bash
+docker compose up --build
+curl http://localhost:8000/hello
+open http://localhost:16686
+```

--- a/simple/README.md
+++ b/simple/README.md
@@ -1,0 +1,45 @@
+# Simple
+
+OpenTelemetry の基本的なトレーシングを示す最小構成のサンプルです。
+
+## アーキテクチャ
+
+```
+┌──────────────┐
+│  API (:8000) │──→ httpbin.org/delay/1
+└──────┬───────┘
+       │ Jaeger HTTP
+       ▼
+┌──────────────┐
+│   Jaeger     │
+│ (:16686 UI)  │
+└──────────────┘
+```
+
+単一の HTTP サーバーと Jaeger のみのシンプルな構成です。
+
+## 特徴
+
+- **最小構成**: サービス1つ + Jaeger のみ
+- **手動スパン作成**: `tracer.Start()` で op1, op2, op3 の子スパンを明示的に作成
+- **HTTP 自動計装**: `otelhttp.NewHandler`（受信）+ `otelhttp.NewTransport`（送信）
+- **外部 HTTP 呼び出し**: httpbin.org への HTTP クライアント呼び出しもトレースに含まれる
+- **AlwaysSample**: 全リクエストをトレース
+
+## `/hello` のトレース構造
+
+```
+server (otelhttp)
+├── op1 (100ms)
+├── op2 (100ms)
+├── HTTP GET httpbin.org/delay/1
+└── op3 (100ms)
+```
+
+## 使い方
+
+```bash
+docker compose up --build
+curl http://localhost:8000/hello
+open http://localhost:16686
+```


### PR DESCRIPTION
## Summary
- `simple/README.md`: 最小構成の OTel トレーシング
- `bridge/README.md`: OpenCensus → OpenTelemetry ブリッジ + BigTable
- `collector/README.md`: OTel Collector 経由のマルチバックエンド（Jaeger + Zipkin）
- `microservice/README.md`: HTTP + gRPC マイクロサービス分散トレーシング
- `multi-package/README.md`: 複数 Go パッケージにまたがるトレーシング

## Test plan
- [ ] 各 README の内容が実装と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)