### PR TITLE
refactor: change Envoy from front-proxy to sidecar pattern

### DIFF
--- a/envoy/README.md
+++ b/envoy/README.md
@@ -1,79 +1,74 @@
 # Envoy Sidecar
 
-Envoy プロキシをフロントプロキシとして配置し、OpenTelemetry の分散トレーシングに参加させるサンプルです。
+各マイクロサービスに Envoy サイドカーを配置し、サービス間通信を含めた分散トレーシングを実現するサンプルです。
 
 ## アーキテクチャ
 
 ```
-                        ┌──────────┐     gRPC     ┌──────────────┐
-Client ──→ Envoy ──────→│ Gateway  │─────────────→│ Backend-gRPC │
-          (:10000)       │ (:8000)  │              │ (:8080)      │
-                        └────┬─────┘              └──────┬───────┘
-Envoy ─┐                     │ Jaeger HTTP                │ Jaeger HTTP
- OTLP  │                     └──────────┬────────────────┘
- gRPC  │                                ▼
-       └──────────────→┌─────────────────┐
-                       │     Jaeger       │
-                       │  (:16686 UI)     │
-                       └─────────────────┘
+              Envoy                              Envoy
+            (GW sidecar)                      (Backend sidecar)
+Client ──→ [:10000 HTTP] ──→ Gateway ──→ [:10001 gRPC] ──→ Backend-gRPC
+                              (:8000)                        (:8080)
+
+  Envoy-GW ─┐        Gateway ─┐       Envoy-Backend ─┐   Backend ─┐
+   OTLP gRPC│    Jaeger HTTP  │         OTLP gRPC    │  Jaeger HTTP│
+             └──→ Jaeger (:16686) ←────────────────────┘←──────────┘
 ```
+
+**ポイント**: Gateway は `envoy-backend:10001` に gRPC 接続する（`backend-grpc:8080` に直接ではない）。
+Backend への通信も Envoy サイドカーを経由するため、サービス間のネットワークレイヤもトレースに含まれます。
 
 ## 特徴
 
-- **Envoy がトレースに参加**: Envoy 自身がスパンを生成し、Jaeger にエクスポート
+- **サイドカーパターン**: 各サービスに専用の Envoy を配置（envoy-gateway, envoy-backend）
 - **W3C Trace Context**: Envoy の OpenTelemetry tracer で `traceparent` ヘッダーを生成・伝搬
-- **OTLP gRPC エクスポート**: Envoy → Jaeger (:4317) へ OTLP gRPC で直接送信
-- **AlwaysSample**: 全リクエストをトレース（Envoy 側も 100% サンプリング）
+- **4サービスのスパンが統合**: Envoy-GW → Gateway → Envoy-Backend → Backend-gRPC
+- **gRPC プロキシ**: Envoy-Backend が gRPC (HTTP/2) をプロキシし、トレースに参加
 
 ## トレース構造
 
 `curl http://localhost:10000/hello` のトレース:
 
 ```
-envoy-front-proxy: ingress_http              ← Envoy が生成
-└── gateway: server (otelhttp)               ← Gateway が生成
-    ├── gateway: grpc.Greeter/SayHello       ← gRPC クライアント
-    │   └── backend: grpc.Greeter/SayHello   ← gRPC サーバー
-    │       └── backend: operation (200ms)
+envoy-gateway: inbound_http                     ← Envoy-GW が生成
+└── gateway: server (otelhttp)                   ← Gateway が生成
+    ├── gateway: grpc.Greeter/SayHello           ← gRPC クライアント
+    │   └── envoy-backend: inbound_grpc          ← Envoy-Backend が生成
+    │       └── backend: grpc.Greeter/SayHello   ← Backend が生成
+    │           └── backend: operation (200ms)
     └── gateway: op1 (100ms)
 ```
 
-Envoy・Gateway・Backend の3サービスのスパンが同一トレースに統合されます。
+## Envoy 設定
 
-## Envoy 設定（sidecar/envoy.yaml）
+| ファイル | 役割 | Listen | 転送先 |
+|---------|------|--------|--------|
+| `envoy-gateway.yaml` | GW サイドカー（HTTP 受信） | `:10000` | `gateway:8000` |
+| `envoy-backend.yaml` | Backend サイドカー（gRPC 受信） | `:10001` | `backend-grpc:8080` |
 
-```yaml
-tracing:
-  provider:
-    name: envoy.tracers.opentelemetry
-    typed_config:
-      "@type": .../OpenTelemetryConfig
-      grpc_service:
-        envoy_grpc:
-          cluster_name: otel_collector   # Jaeger の OTLP gRPC エンドポイント
-      service_name: envoy-front-proxy
-```
+両方とも OpenTelemetry tracer で Jaeger (:4317) に OTLP gRPC でトレースをエクスポートします。
 
 ## microservice/ との違い
 
 | 項目 | envoy/ (本サンプル) | microservice/ |
 |------|--------------------|---------------|
-| フロントプロキシ | Envoy (:10000) | なし（Gateway に直接アクセス） |
-| Envoy のスパン | あり | なし |
-| 伝搬フォーマット | W3C (Envoy OTel tracer) | W3C (OTel SDK のみ) |
-| クライアントのアクセス先 | `:10000` (Envoy) | `:8000` (Gateway) |
+| Envoy サイドカー | 各サービスに配置 | なし |
+| サービス間通信 | Envoy 経由 | 直接 gRPC |
+| トレース対象 | アプリ + ネットワーク層 | アプリのみ |
+| スパン数 | 多い（Envoy 分が追加） | 少ない |
+| クライアントのアクセス先 | `:10000` (Envoy-GW) | `:8000` (Gateway) |
 
 ## 使い方
 
 ```bash
 docker compose up --build
 
-# Envoy 経由でリクエスト送信
+# Envoy-GW 経由でリクエスト送信
 curl http://localhost:10000/hello
 
-# Jaeger UI でトレースを確認
+# Jaeger UI でトレースを確認（4サービスのスパンが統合）
 open http://localhost:16686
 
-# Envoy admin UI
+# Envoy-GW admin UI
 open http://localhost:9901
 ```

--- a/envoy/docker-compose.yml
+++ b/envoy/docker-compose.yml
@@ -1,14 +1,26 @@
 version: "3"
 
 services:
-  envoy:
+  # Gateway sidecar: receives client HTTP, forwards to gateway
+  envoy-gateway:
     build:
       context: ./sidecar
+      args:
+        - CONFIG_FILE=envoy-gateway.yaml
     ports:
       - "10000:10000"
       - "9901:9901"
     depends_on:
       - gateway
+      - jaeger
+  # Backend sidecar: receives gRPC from gateway, forwards to backend-grpc
+  envoy-backend:
+    build:
+      context: ./sidecar
+      args:
+        - CONFIG_FILE=envoy-backend.yaml
+    depends_on:
+      - backend-grpc
       - jaeger
   gateway:
     build:
@@ -17,7 +29,7 @@ services:
       args:
         - TARGET=gateway
     environment:
-      - BACKEND_ADDR=backend-grpc:8080
+      - BACKEND_ADDR=envoy-backend:10001
       - SAMPLING_RATIO=1
       - EXPORTER_ENDPOINT=http://jaeger:14268/api/traces
     depends_on:
@@ -38,7 +50,6 @@ services:
     ports:
       - "16686:16686"
       - "14268:14268"
-      - "9411:9411"
     environment:
       - COLLECTOR_ZIPKIN_HOST_PORT=:9411
       - COLLECTOR_OTLP_ENABLED=true

--- a/envoy/sidecar/Dockerfile
+++ b/envoy/sidecar/Dockerfile
@@ -1,3 +1,4 @@
 FROM envoyproxy/envoy:v1.28-latest
 
-ADD envoy.yaml /etc/envoy/envoy.yaml
+ARG CONFIG_FILE=envoy-gateway.yaml
+ADD ${CONFIG_FILE} /etc/envoy/envoy.yaml

--- a/envoy/sidecar/envoy-backend.yaml
+++ b/envoy/sidecar/envoy-backend.yaml
@@ -1,18 +1,18 @@
 admin:
   address:
-    socket_address: { address: 0.0.0.0, port_value: 9901 }
+    socket_address: { address: 0.0.0.0, port_value: 9902 }
 
 static_resources:
   listeners:
-    - name: front_proxy
+    - name: inbound_grpc
       address:
-        socket_address: { address: 0.0.0.0, port_value: 10000 }
+        socket_address: { address: 0.0.0.0, port_value: 10001 }
       filter_chains:
         - filters:
             - name: envoy.filters.network.http_connection_manager
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                stat_prefix: ingress_http
+                stat_prefix: inbound_grpc
                 codec_type: AUTO
                 tracing:
                   provider:
@@ -23,7 +23,7 @@ static_resources:
                         envoy_grpc:
                           cluster_name: otel_collector
                         timeout: 0.250s
-                      service_name: envoy-front-proxy
+                      service_name: envoy-backend
                   random_sampling:
                     value: 100
                 access_log:
@@ -34,34 +34,39 @@ static_resources:
                 route_config:
                   name: local_route
                   virtual_hosts:
-                    - name: gateway
+                    - name: local_service
                       domains: ["*"]
                       routes:
                         - match: { prefix: "/" }
                           route:
-                            cluster: gateway
+                            cluster: local_app
                             timeout: 30s
                           decorator:
-                            operation: gateway
+                            operation: backend-inbound
                 http_filters:
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                       start_child_span: true
   clusters:
-    - name: gateway
+    - name: local_app
       connect_timeout: 0.25s
       type: STRICT_DNS
       lb_policy: ROUND_ROBIN
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       load_assignment:
-        cluster_name: gateway
+        cluster_name: local_app
         endpoints:
           - lb_endpoints:
               - endpoint:
                   address:
                     socket_address:
-                      address: gateway
-                      port_value: 8000
+                      address: backend-grpc
+                      port_value: 8080
     - name: otel_collector
       connect_timeout: 1s
       type: STRICT_DNS

--- a/envoy/sidecar/envoy-gateway.yaml
+++ b/envoy/sidecar/envoy-gateway.yaml
@@ -1,0 +1,82 @@
+admin:
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+    - name: inbound
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 10000 }
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: inbound_http
+                codec_type: AUTO
+                tracing:
+                  provider:
+                    name: envoy.tracers.opentelemetry
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: otel_collector
+                        timeout: 0.250s
+                      service_name: envoy-gateway
+                  random_sampling:
+                    value: 100
+                access_log:
+                  - name: envoy.access_loggers.file
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                      path: /dev/stdout
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: local_app
+                            timeout: 30s
+                          decorator:
+                            operation: gateway-inbound
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      start_child_span: true
+  clusters:
+    - name: local_app
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: local_app
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: gateway
+                      port_value: 8000
+    - name: otel_collector
+      connect_timeout: 1s
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: otel_collector
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: jaeger
+                      port_value: 4317


### PR DESCRIPTION
## Summary
- front-proxy パターンから **サイドカーパターン** に変更
- `envoy-gateway`: Gateway の前段サイドカー（HTTP 受信 → `gateway:8000`）
- `envoy-backend`: Backend の前段サイドカー（gRPC 受信 → `backend-grpc:8080`）
- Gateway の `BACKEND_ADDR` を `envoy-backend:10001` に変更（サイドカー経由）
- README をサイドカーパターンに合わせて更新

## Architecture
```
Client → [Envoy-GW :10000] → [Gateway :8000] → [Envoy-Backend :10001] → [Backend-gRPC :8080]
```

4サービス（Envoy-GW → Gateway → Envoy-Backend → Backend）のスパンが1つのトレースに統合

## Test plan
- [ ] `docker compose up --build` で起動確認
- [ ] `curl http://localhost:10000/hello` でリクエスト送信
- [ ] Jaeger UI で envoy-gateway → gateway → envoy-backend → backend-grpc の4サービスのスパンが統合されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)