### PR TITLE
fix: fix Envoy tracing config for trace context propagation

### DIFF
--- a/envoy/gateway/main.go
+++ b/envoy/gateway/main.go
@@ -67,7 +67,8 @@ func (h *handler) hello(w http.ResponseWriter, r *http.Request) {
 	}
 	_, err := h.cli.SayHello(r.Context(), req)
 	if err != nil {
-		log.Fatal(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	Operation(r.Context())

--- a/envoy/sidecar/Dockerfile
+++ b/envoy/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.28-latest
+FROM envoyproxy/envoy:v1.31-latest
 
 ARG CONFIG_FILE=envoy-gateway.yaml
 ADD ${CONFIG_FILE} /etc/envoy/envoy.yaml

--- a/envoy/sidecar/envoy-backend.yaml
+++ b/envoy/sidecar/envoy-backend.yaml
@@ -15,6 +15,7 @@ static_resources:
                 stat_prefix: inbound_grpc
                 codec_type: AUTO
                 tracing:
+                  spawn_upstream_span: true
                   provider:
                     name: envoy.tracers.opentelemetry
                     typed_config:
@@ -24,8 +25,6 @@ static_resources:
                           cluster_name: otel_collector
                         timeout: 0.250s
                       service_name: envoy-backend
-                  random_sampling:
-                    value: 100
                 access_log:
                   - name: envoy.access_loggers.file
                     typed_config:
@@ -47,7 +46,6 @@ static_resources:
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                      start_child_span: true
   clusters:
     - name: local_app
       connect_timeout: 0.25s

--- a/envoy/sidecar/envoy-gateway.yaml
+++ b/envoy/sidecar/envoy-gateway.yaml
@@ -15,6 +15,7 @@ static_resources:
                 stat_prefix: inbound_http
                 codec_type: AUTO
                 tracing:
+                  spawn_upstream_span: true
                   provider:
                     name: envoy.tracers.opentelemetry
                     typed_config:
@@ -24,8 +25,6 @@ static_resources:
                           cluster_name: otel_collector
                         timeout: 0.250s
                       service_name: envoy-gateway
-                  random_sampling:
-                    value: 100
                 access_log:
                   - name: envoy.access_loggers.file
                     typed_config:
@@ -47,7 +46,6 @@ static_resources:
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                      start_child_span: true
   clusters:
     - name: local_app
       connect_timeout: 0.25s


### PR DESCRIPTION
## Summary
- `start_child_span` (deprecated) → `spawn_upstream_span: true` (HCM レベル)
- `random_sampling` 削除（デフォルト 100%）
- Envoy イメージ `v1.28` → `v1.31`（OTel tracer の安定性向上）

## Problem
Envoy のトレースが Gateway/Backend と繋がらず、envoy-gateway のスパンのみが独立して表示されていた

## Test plan
- [ ] `docker compose up --build` で再起動
- [ ] Jaeger UI で4サービスのスパンが同一トレースに統合されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)