### PR TITLE
feat: add k6 load test for envoy sidecar sample

### DIFF
--- a/envoy/docker-compose.yml
+++ b/envoy/docker-compose.yml
@@ -53,3 +53,10 @@ services:
     environment:
       - COLLECTOR_ZIPKIN_HOST_PORT=:9411
       - COLLECTOR_OTLP_ENABLED=true
+  k6:
+    image: grafana/k6:latest
+    volumes:
+      - ./k6:/scripts
+    command: run /scripts/loadtest.js
+    depends_on:
+      - envoy-gateway

--- a/envoy/k6/loadtest.js
+++ b/envoy/k6/loadtest.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 10 },
+    { duration: '1m', target: 10 },
+    { duration: '10s', target: 0 },
+  ],
+};
+
+export default function () {
+  const res = http.get('http://envoy-gateway:10000/hello');
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+  });
+  sleep(0.5);
+}


### PR DESCRIPTION
## Summary
- `envoy/k6/loadtest.js` を追加
- `docker-compose.yml` に k6 サービスを追加
- `docker compose up --build` で自動的に負荷テスト開始

🤖 Generated with [Claude Code](https://claude.com/claude-code)